### PR TITLE
Modify loading screen

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1028,7 +1028,6 @@ Date: December 2024
   <!-- Loading Screen -->
   <div class="loading-screen" id="loadingScreen">
     <div class="loading-content">
-      <div class="loading-plant">🌱</div>
       <div class="loading-text">Welcome to Fernly Health</div>
     </div>
   </div>
@@ -1245,10 +1244,12 @@ window.addEventListener('load', async () => {
     }
   }
 
-  document.getElementById('loadingScreen').classList.add('fade-out');
   setTimeout(() => {
-    document.getElementById('loadingScreen').style.display = 'none';
-  }, 1000);
+    document.getElementById('loadingScreen').classList.add('fade-out');
+    setTimeout(() => {
+      document.getElementById('loadingScreen').style.display = 'none';
+    }, 1000);
+  }, 4000);
 });
 
 // Smooth scrolling


### PR DESCRIPTION
## Summary
- remove the plant animation from the loading screen
- keep only the welcome message
- delay fade out so the welcome text is shown for at least four seconds

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685dedecfea4832aaa707e3c1ee45944