### PR TITLE
Add medication query tests

### DIFF
--- a/tests/medicationQueries.test.js
+++ b/tests/medicationQueries.test.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+
+// Setup minimal browser-like globals
+global.window = {};
+global.localStorage = {
+  getItem() { return null; },
+  setItem() {},
+  removeItem() {}
+};
+
+// Load data and AI code
+require('../docs/therapy-speech.js');
+require('../docs/medications-data.js');
+require('../docs/ai.js');
+
+function resetContext() {
+  window.conversationContext.assessmentInProgress = false;
+  window.conversationContext.assessmentPrompted = false;
+  window.conversationContext.detectedSymptoms = {};
+  window.conversationContext.messages = [];
+  window.conversationContext.questionCount = 0;
+}
+
+async function runTests() {
+  console.log('Testing medication related queries...');
+
+  // Specific medication should return detailed info with disclaimer
+  resetContext();
+  let response = await window.generateAIResponse('Tell me about Prozac medication');
+  assert.ok(response.includes('Prozac (Fluoxetine)'), 'Should mention the medication name');
+  assert.ok(response.includes('educational purposes only'), 'Should include medication disclaimer');
+
+  // Generic keyword should still return a response
+  resetContext();
+  response = await window.generateAIResponse('medication');
+  assert.ok(response && response.length > 0, 'Should respond to generic medication keyword');
+  assert.ok(!response.includes('educational purposes only'), 'Generic keyword alone should not include specific medication info');
+
+  // General question about medication use
+  resetContext();
+  response = await window.generateAIResponse('What medication helps with depression?');
+  assert.ok(response && response.length > 0, 'Should respond to broad medication question');
+
+  console.log('Medication query tests passed');
+}
+
+runTests().catch(err => {
+  console.error('Medication query tests failed:', err);
+  process.exit(1);
+});

--- a/tests/textUpdates.test.js
+++ b/tests/textUpdates.test.js
@@ -2,7 +2,12 @@ const assert = require('assert');
 const fs = require('fs');
 
 // Test that the text changes were made correctly
-const indexHtml = fs.readFileSync('/home/runner/work/Fernly/Fernly/docs/index.html', 'utf8');
+// Use path relative to the repository root so tests work in any environment
+const path = require('path');
+const indexHtml = fs.readFileSync(
+  path.join(__dirname, '..', 'docs', 'index.html'),
+  'utf8'
+);
 
 // Test 1: Check that the main heading was updated correctly
 assert.ok(indexHtml.includes('Ask Away We\'re Listening'), 'Main heading should be updated without em dash');


### PR DESCRIPTION
## Summary
- ensure tests can locate `index.html` regardless of environment
- add new medication-focused test coverage

## Testing
- `node tests/maybeOfferAssessment.test.js`
- `node tests/singleWordInputs.test.js`
- `node tests/textUpdates.test.js`
- `node tests/medicationQueries.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685f12f00ac4832abb3de562f48e06cf