### PR TITLE
Add browser-based AI assistant to docs

### DIFF
--- a/docs/aiAssistant.js
+++ b/docs/aiAssistant.js
@@ -1,0 +1,149 @@
+// aiAssistant.js
+
+// Persistent state for files and preferences
+let aiState = {
+  files: [],
+  preferences: { showSources: true, chunkSize: 250, maxHistory: 50 }
+};
+if (localStorage.getItem('aiChatState')) try { aiState = JSON.parse(localStorage.getItem('aiChatState')); } catch {}
+function saveAiState() { localStorage.setItem('aiChatState', JSON.stringify(aiState)); }
+function chunkText(text, size) {
+  const out = [];
+  for (let i = 0; i < text.length; i += size) out.push(text.slice(i, i + size));
+  return out;
+}
+
+// File uploader
+export async function aiHandleFileUpload(inputId, statusId) {
+  const files = document.getElementById(inputId).files;
+  const loaded = [];
+  for (let file of files) {
+    // Skip very large files to avoid blocking the browser
+    if (file.size > 1024 * 1024) {
+      console.warn(`Skipping ${file.name}: file too large.`);
+      continue;
+    }
+    let text = '';
+    try {
+      text = await file.text();
+    } catch (err) {
+      console.error('Failed to read file', err);
+      continue;
+    }
+    const chunks = chunkText(text, aiState.preferences.chunkSize);
+    aiState.files.push({
+      name: file.name,
+      type: file.type,
+      content: text,
+      chunks: chunks.map((txt, i) => ({ text: txt, start: i * aiState.preferences.chunkSize, end: (i + 1) * aiState.preferences.chunkSize }))
+    });
+    loaded.push(file.name);
+  }
+  if (loaded.length) {
+    saveAiState();
+  }
+  document.getElementById(statusId).innerText = loaded.length ? `Loaded: ${loaded.join(', ')}` : 'No files loaded';
+}
+
+// Semantic Search (MiniLM)
+let embedderModel;
+async function ensureEmbedderLoaded() {
+  if (!embedderModel) {
+    try {
+      embedderModel = await window.transformers.load('Xenova/all-MiniLM-L6-v2');
+    } catch (e) {
+      console.error('Failed to load embedder model', e);
+      throw e;
+    }
+  }
+}
+async function embed(text) {
+  await ensureEmbedderLoaded();
+  try {
+    const output = await embedderModel.embed(text);
+    return output.data;
+  } catch (e) {
+    console.error('Embedding failed', e);
+    throw e;
+  }
+}
+function cosineSimilarity(a, b) {
+  let sum = 0, normA = 0, normB = 0;
+  for (let i = 0; i < a.length; ++i) {
+    sum += a[i] * b[i]; normA += a[i] ** 2; normB += b[i] ** 2;
+  }
+  return sum / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+// LLM (Phi-3 Mini) setup
+let llmModel, llmReady = false, llmError = false;
+export async function ensureLlmLoaded(statusId) {
+  if (!llmModel && !llmError) {
+    document.getElementById(statusId).innerText = "Loading AI model…";
+    try {
+      llmModel = await window.transformers.load('Xenova/phi-3-mini-4k-instruct');
+      llmReady = true;
+      document.getElementById(statusId).innerText = "AI model ready!";
+    } catch (e) {
+      document.getElementById(statusId).innerText = "AI model failed to load. Showing best-matching file content only.";
+      llmReady = false;
+      llmError = true;
+    }
+  }
+}
+
+// Main AI answer logic
+export async function aiGetAnswer(query, statusId) {
+  document.getElementById(statusId).innerText = "Thinking…";
+  try {
+    await ensureEmbedderLoaded();
+  } catch (e) {
+    console.error('Embedder unavailable', e);
+  }
+  let hits = [];
+  if (aiState.files.length && embedderModel) {
+    try {
+      const queryEmbedding = await embed(query);
+      for (let f of aiState.files)
+        for (let chunk of f.chunks)
+          if (!chunk.embedding) chunk.embedding = await embed(chunk.text);
+      let scored = [];
+      for (let f of aiState.files) for (let chunk of f.chunks) {
+        const score = cosineSimilarity(queryEmbedding, chunk.embedding);
+        scored.push({ file: f.name, text: chunk.text, score, snippet: `${chunk.start}-${chunk.end}` });
+      }
+      scored.sort((a, b) => b.score - a.score);
+      hits = scored.slice(0, 3).filter(x => x.score > 0.2);
+    } catch (e) {
+      console.error('Semantic search failed', e);
+    }
+  }
+  await ensureLlmLoaded(statusId);
+  let contextText = hits.length ? hits.map(h => `[From ${h.file} lines ${h.snippet}]:\n${h.text}`).join('\n---\n') : '';
+  let answerText;
+  if (!llmReady) {
+    answerText = hits.length
+      ? hits.map(h => h.text).join('\n---\n') + "<br><em>(AI model unavailable, showing best-matching file content.)</em>"
+      : "Sorry, I couldn't find relevant information in your files.";
+  } else {
+    const systemPrompt = "You are an expert assistant. Use the provided context from the user's files to answer the question. If there is no relevant information, say so. Cite the file and snippet if you use it.";
+    const prompt = [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: `Context:\n${contextText}\n\nQuestion: ${query}` }
+    ];
+    try {
+      answerText = await llmModel.generate(
+        prompt.map(m => `<|${m.role}|>\n${m.content}`).join('\n'),
+        { max_new_tokens: 256, temperature: 0.2, stop: ["<|user|>", "<|system|>"] }
+      ).then(out => out.generated_text.trim());
+    } catch (err) {
+      console.error('LLM generation failed', err);
+      llmReady = false;
+      answerText = hits.length
+        ? hits.map(h => h.text).join('\n---\n') + "<br><em>(AI model error, showing best-matching file content.)</em>"
+        : "Sorry, I couldn't find relevant information in your files.";
+    }
+  }
+  document.getElementById(statusId).innerText = '';
+  return { text: answerText, sources: hits.map(h => ({ file: h.file, snippet: h.snippet })) };
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,6 +25,7 @@ Date: December 2024
   <script src="therapy-speech.js"></script>
   <!-- AI Chat functionality - depends on WebLLM and fallback-data being loaded first -->
   <script src="ai.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xenova/transformers@2.13.0/dist/transformers.min.js"></script>
   <!-- CSS STYLES WILL GO HERE -->
   <style>
     * {
@@ -553,6 +554,30 @@ Date: December 2024
       line-height: 1.4;
     }
 
+    .upload-help {
+      font-size: 0.75rem;
+      color: #555;
+      margin-top: 0.5rem;
+    }
+
+    #aiFileInput {
+      margin-top: 0.5rem;
+    }
+
+    #aiUploadBtn {
+      background: #619251;
+      color: white;
+      border: none;
+      padding: 0.25rem 0.75rem;
+      border-radius: 4px;
+      cursor: pointer;
+      margin-left: 0.25rem;
+    }
+
+    #aiUploadBtn:hover {
+      background: #4F7942;
+    }
+
     /* Medical Disclaimer - NEW */
     .medical-disclaimer {
       background: rgba(219, 54, 69, 0.1);
@@ -1045,6 +1070,11 @@ Date: December 2024
               </button>
             </div>
           </form>
+          <input type="file" id="aiFileInput" multiple>
+          <button id="aiUploadBtn">Upload Files</button>
+          <div class="upload-help">Upload plain text files (max 1&nbsp;MB each) to help the assistant answer more accurately.</div>
+          <span id="aiFileStatus" style="font-size:0.9em;color:#888;"></span>
+          <span id="aiAIStatus" style="font-size:0.9em;color:#888;margin-left:1em;"></span>
           <div class="disclaimer">
             This AI assistant provides general information only. It's not a substitute for professional medical advice. If you're in crisis, please call 988 or seek immediate help.
           </div>
@@ -1151,8 +1181,8 @@ Date: December 2024
   <script>
 // Initialize loading screen and AI
 window.addEventListener('load', () => {
-  // No need for complex CDN loading setup - using local transformers.min.js file
-  console.log('Transformers.js loaded from local file');
+  // Transformers.js loads from the CDN declared in the page head
+  console.log('Transformers.js loaded from CDN');
 
   setTimeout(() => {
     document.getElementById('loadingScreen').classList.add('fade-out');
@@ -1331,19 +1361,19 @@ async function sendMessage() {
   const typingIndicator = addTypingIndicator();
   
   try {
-    // Generate response using AI or fallback
-    const response = await generateAIResponse(message);
-    
+    // Generate response using new AI assistant
+    const answer = await window.aiGetAnswer(message, 'aiAIStatus');
+
     // Remove typing indicator and add AI response
     if (typingIndicator && typingIndicator.parentNode) {
       chatMessages.removeChild(typingIndicator);
     }
-    
-    // Check if we're in fallback mode and add appropriate styling
-    const responseElement = addMessage(response, 'bot');
-    if (isFallbackMode || !isAILoaded) {
-      responseElement.classList.add('fallback-response');
-    }
+
+    const responseElement = addMessage(answer.text + (
+      answer.sources?.length
+        ? `<div style="font-size:0.85em;color:#888;">Source: ${answer.sources.map(s => `${s.file} [${s.snippet}]`).join(', ')}</div>`
+        : ''
+    ), 'bot');
   } catch (error) {
     console.error('Error generating response:', error);
     if (typingIndicator && typingIndicator.parentNode) {
@@ -1432,6 +1462,15 @@ document.querySelectorAll('.blog-card').forEach(el => {
   el.style.transition = 'opacity 0.6s ease, transform 0.6s ease';
   observer.observe(el);
 });
+
+</script>
+<script type="module">
+import { aiHandleFileUpload, aiGetAnswer, ensureLlmLoaded } from './aiAssistant.js';
+window.aiGetAnswer = aiGetAnswer;
+window.aiHandleFileUpload = aiHandleFileUpload;
+window.ensureLlmLoaded = ensureLlmLoaded;
+document.getElementById('aiUploadBtn').onclick = () => aiHandleFileUpload('aiFileInput', 'aiFileStatus');
+ensureLlmLoaded('aiAIStatus');
 </script>
 </body>
 


### PR DESCRIPTION
## Summary
- integrate new browser-only AI assistant using transformers.js
- enable file uploads and semantic search via `aiAssistant.js`
- preload the LLM model and handle answers client-side
- add file size checks for performance
- clarify that transformers.js is loaded from CDN
- improve error handling and UI styling for file uploads

## Testing
- `node tests/maybeOfferAssessment.test.js && node tests/medicationQueries.test.js && node tests/singleWordInputs.test.js && node tests/textUpdates.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685fae12bfe0832a87a9ee4df93f560d