### PR TITLE
Improve local Transformers.js loading

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26,7 +26,7 @@ Date: December 2024
   <!-- AI Chat functionality -->
   <script src="ai.js"></script>
   <!-- Load Transformers.js locally with CDN fallback -->
-  <script id="transformers-cdn" src="transformers.min.js"></script>
+  <script id="transformers-cdn" type="module" src="transformers.min.js"></script>
   <script>
     (function(){
       const scriptEl = document.getElementById('transformers-cdn');
@@ -34,6 +34,7 @@ Date: December 2024
       function loadBackup(){
         if(status) status.innerText = 'Local library failed, fetching from CDN...';
         const alt = document.createElement('script');
+        alt.type = 'module';
         alt.src = 'https://cdn.jsdelivr.net/npm/@xenova/transformers@2.13.0/dist/transformers.min.js';
         alt.onload = () => {
           if(status) status.innerText = '';


### PR DESCRIPTION
## Summary
- ensure the local Transformers.js script loads as a module
- set the CDN fallback script to `type="module"`

## Testing
- `node tests/textUpdates.test.js`
- `node tests/maybeOfferAssessment.test.js`
- `node tests/medicationQueries.test.js`
- `node tests/singleWordInputs.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685fe08293d4832a9ae6776496676797