### PR TITLE
Improve hero typewriter timing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1298,7 +1298,7 @@ function startHeroWordsAnimation() {
         el.textContent += text.charAt(i);
         i++;
         if (i >= text.length) clearInterval(interval);
-      }, 80);
+      }, 100);
     }, delay);
   };
 
@@ -1306,11 +1306,14 @@ function startHeroWordsAnimation() {
   if (words[1]) typeWriter(words[1], 2000);
   if (words[2]) typeWriter(words[2], 4000);
 
-  // Show tagline after last word finishes typing
-  const taglineDelay = 4000 + words[2].textContent.length * 80 + 500;
+  // Type tagline after last word finishes typing
+  const taglineDelay = 4000 + words[2].textContent.length * 100 + 500;
   setTimeout(() => {
     const tagline = document.querySelector('.hero .tagline');
-    if (tagline) tagline.classList.add('show');
+    if (tagline) {
+      tagline.classList.add('show');
+      typeWriter(tagline, 0);
+    }
   }, taglineDelay);
 }
 


### PR DESCRIPTION
## Summary
- slow the hero typewriter animation slightly
- type out the tagline text after the hero words

## Testing
- `node tests/maybeOfferAssessment.test.js && node tests/medicationQueries.test.js && node tests/singleWordInputs.test.js && node tests/textUpdates.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6860638217a8832aae860f13cab33395