### PR TITLE
Fix insurance carousel

### DIFF
--- a/docs/assets/insurance/aetna.svg
+++ b/docs/assets/insurance/aetna.svg
@@ -1,3 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
-  <text x="0" y="30" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#742384" font-weight="bold">aetna</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 40">
+  <path d="M15 20c0-5 4-9 9-9s9 4 9 9c0 4-2 7-6 8v7h-6v-7c-4-1-6-4-6-8z" fill="#742384"/>
+  <text x="40" y="30" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#742384" font-weight="bold">aetna</text>
 </svg>

--- a/docs/assets/insurance/anthem.svg
+++ b/docs/assets/insurance/anthem.svg
@@ -1,3 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
-  <text x="0" y="30" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#005DAA" font-weight="bold">Anthem</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 40">
+  <text x="0" y="30" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#005DAA" font-weight="bold">Anthem</text>
+  <rect x="120" y="5" width="8" height="30" fill="#005DAA"/>
+  <rect x="114" y="15" width="20" height="8" fill="#005DAA"/>
 </svg>

--- a/docs/assets/insurance/bluecross.svg
+++ b/docs/assets/insurance/bluecross.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
-  <rect x="30" width="20" height="80" fill="#0072CE"/>
-  <rect y="30" width="80" height="20" fill="#0072CE"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 40">
+  <rect x="20" y="5" width="20" height="30" fill="#0072CE"/>
+  <rect x="10" y="15" width="40" height="10" fill="#0072CE"/>
+  <path d="M90 5l10 10 10-10h10v30h-10V15l-10 10-10-10v20H80V5h10z" fill="#0072CE"/>
 </svg>

--- a/docs/assets/insurance/cigna.svg
+++ b/docs/assets/insurance/cigna.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
-  <circle cx="40" cy="20" r="10" fill="#6DBE45"/>
-  <path d="M40 30 L40 60" stroke="#6DBE45" stroke-width="4"/>
-  <path d="M20 40 C30 35 50 35 60 40" fill="none" stroke="#6DBE45" stroke-width="4"/>
-  <path d="M20 50 C30 45 50 45 60 50" fill="none" stroke="#6DBE45" stroke-width="4"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <circle cx="60" cy="20" r="10" fill="#6DBE45"/>
+  <path d="M60 30v20" stroke="#6DBE45" stroke-width="4"/>
+  <path d="M40 35c5-5 15-5 20 0s15 5 20 0" fill="none" stroke="#6DBE45" stroke-width="4"/>
+  <path d="M40 45c5-5 15-5 20 0s15 5 20 0" fill="none" stroke="#6DBE45" stroke-width="4"/>
 </svg>

--- a/docs/assets/insurance/humana.svg
+++ b/docs/assets/insurance/humana.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 40">
-  <text x="0" y="30" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#65B32E" font-weight="bold">Humana</text>
+  <text x="0" y="30" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#65B32E" font-weight="bold">Humana</text>
 </svg>

--- a/docs/assets/insurance/kaiser.svg
+++ b/docs/assets/insurance/kaiser.svg
@@ -1,3 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40">
-  <text x="0" y="30" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#005DAA" font-weight="bold">Kaiser</text>
+  <path d="M20 30L30 10l10 20 10-20 10 20 10-20 10 20" fill="#005DAA"/>
+  <circle cx="35" cy="5" r="5" fill="#005DAA"/>
+  <circle cx="55" cy="5" r="5" fill="#005DAA"/>
+  <circle cx="75" cy="5" r="5" fill="#005DAA"/>
 </svg>

--- a/docs/assets/insurance/medicaid.svg
+++ b/docs/assets/insurance/medicaid.svg
@@ -1,3 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40">
-  <text x="0" y="30" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#005DAA" font-weight="bold">Medicaid</text>
+  <path d="M10 30h140" stroke="#005DAA" stroke-width="8"/>
+  <path d="M30 10l20 20 20-20" fill="none" stroke="#005DAA" stroke-width="8"/>
 </svg>

--- a/docs/assets/insurance/medicare.svg
+++ b/docs/assets/insurance/medicare.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40">
-  <text x="0" y="30" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#005DAA" font-weight="bold">Medicare</text>
+  <path d="M20 30L40 10l20 20 20-20 20 20" fill="none" stroke="#005DAA" stroke-width="8"/>
 </svg>

--- a/docs/assets/insurance/optum.svg
+++ b/docs/assets/insurance/optum.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
-  <polygon points="0,40 40,0 80,40" fill="#FF7E0A"/>
-  <text x="90" y="30" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#FF7E0A" font-weight="bold">Optum</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 40">
+  <polygon points="10,30 60,5 110,30 60,35" fill="#FF7E0A"/>
 </svg>

--- a/docs/assets/insurance/tricare.svg
+++ b/docs/assets/insurance/tricare.svg
@@ -1,5 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40">
-  <polygon points="0,30 20,0 40,30" fill="#005DAA"/>
-  <polygon points="60,30 80,0 100,30" fill="#005DAA"/>
-  <polygon points="120,30 140,0 160,30" fill="#005DAA"/>
+  <polygon points="10,30 30,0 50,30" fill="#005DAA"/>
+  <polygon points="55,30 75,0 95,30" fill="#005DAA"/>
+  <polygon points="100,30 120,0 140,30" fill="#005DAA"/>
+  <line x1="10" y1="35" x2="140" y2="35" stroke="#C8102E" stroke-width="4"/>
+  <line x1="20" y1="38" x2="150" y2="38" stroke="#C8102E" stroke-width="4"/>
 </svg>

--- a/docs/assets/insurance/triwest.svg
+++ b/docs/assets/insurance/triwest.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40">
-  <polygon points="0,0 20,20 0,40" fill="#1A1F71"/>
-  <polygon points="160,0 140,20 160,40" fill="#1A1F71"/>
-  <text x="40" y="30" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#1A1F71" font-weight="bold">TriWest</text>
+  <polygon points="10,20 30,0 30,40" fill="#1A1F71"/>
+  <polygon points="150,20 130,0 130,40" fill="#1A1F71"/>
+  <polygon points="40,5 80,35 120,5 80,25" fill="#1A1F71"/>
 </svg>

--- a/docs/assets/insurance/united.svg
+++ b/docs/assets/insurance/united.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
-  <path d="M20 0 v50 a20 20 0 0 0 40 0 v-50 h-10 v50 a10 10 0 0 1 -20 0 v-50z" fill="#005DAA"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 60">
+  <path d="M20 0v35a30 30 0 0 0 60 0V0h-8v35a22 22 0 0 1-44 0V0h-8z" fill="#005DAA"/>
 </svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,6 +51,11 @@ Date: December 2024
   </script>
   <!-- CSS STYLES WILL GO HERE -->
   <style>
+    :root {
+      --scroll-duration: 14s;
+      --slot-width: 140px;
+      --slot-height: 55px;
+    }
     * {
       margin: 0;
       padding: 0;
@@ -1033,9 +1038,7 @@ Date: December 2024
 
   .logo-track {
     display: flex;
-    align-items: center;
-    gap: 3rem;
-    animation: scroll 40s linear infinite;
+    animation: scroll var(--scroll-duration) linear infinite;
   }
 
   .logo-track:hover {
@@ -1043,14 +1046,16 @@ Date: December 2024
   }
 
   .logo-track img {
-    height: 70px;
+    flex: 0 0 var(--slot-width);
+    max-height: var(--slot-height);
+    width: auto;
     object-fit: contain;
-    filter: brightness(0) saturate(0) invert(1);
+    margin: 0 1rem;
   }
 
   @keyframes scroll {
     0%   { transform: translateX(0); }
-    100% { transform: translateX(-50%); }
+    100% { transform: translateX(calc(-1 * (var(--slot-width) + 2rem) * 12)); }
   }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- tweak CSS so insurance logos keep brand colors
- give each logo fixed slot width and height
- speed up carousel scrolling
- replace placeholder insurance logos with more realistic versions

## Testing
- `node tests/maybeOfferAssessment.test.js && node tests/medicationQueries.test.js && node tests/singleWordInputs.test.js && node tests/textUpdates.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6860983b8438832a81d90ab4c577a834