### PR TITLE
Improve gradient noise

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -98,6 +98,7 @@ Date: December 2024
       position: fixed;
       inset: 0;
       background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAATElEQVR4nAXBMREAIQwEwPu3QIEHylOBBVykijRmkBAJKaBLGQU07KL3TjOjqjIi+K21eO9FKQVzTvzujtYaMhNjDOCcQxHh3pu1Vj4teh4idyTiKwAAAABJRU5ErkJggg==");
+      background-size: 8px 8px;
       opacity: .04;
       pointer-events: none;
     }

--- a/docs/login.html
+++ b/docs/login.html
@@ -45,6 +45,7 @@
       position: fixed;
       inset: 0;
       background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAATElEQVR4nAXBMREAIQwEwPu3QIEHylOBBVykijRmkBAJKaBLGQU07KL3TjOjqjIi+K21eO9FKQVzTvzujtYaMhNjDOCcQxHh3pu1Vj4teh4idyTiKwAAAABJRU5ErkJggg==");
+      background-size: 8px 8px;
       opacity: .04;
       pointer-events: none;
     }

--- a/docs/services.html
+++ b/docs/services.html
@@ -46,6 +46,7 @@
       position: fixed;
       inset: 0;
       background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAATElEQVR4nAXBMREAIQwEwPu3QIEHylOBBVykijRmkBAJKaBLGQU07KL3TjOjqjIi+K21eO9FKQVzTvzujtYaMhNjDOCcQxHh3pu1Vj4teh4idyTiKwAAAABJRU5ErkJggg==");
+      background-size: 8px 8px;
       opacity: .04;
       pointer-events: none;
     }

--- a/docs/team.html
+++ b/docs/team.html
@@ -46,6 +46,7 @@
       position: fixed;
       inset: 0;
       background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAATElEQVR4nAXBMREAIQwEwPu3QIEHylOBBVykijRmkBAJKaBLGQU07KL3TjOjqjIi+K21eO9FKQVzTvzujtYaMhNjDOCcQxHh3pu1Vj4teh4idyTiKwAAAABJRU5ErkJggg==");
+      background-size: 8px 8px;
       opacity: .04;
       pointer-events: none;
     }


### PR DESCRIPTION
## Summary
- smooth out gradient noise by setting `background-size` on the noise overlay

## Testing
- `node tests/maybeOfferAssessment.test.js`
- `node tests/singleWordInputs.test.js`
- `node tests/medicationQueries.test.js`
- `node tests/textUpdates.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6860bc477200832aad94ba0b6c26544e