### PR TITLE
Add spacing above insurance section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1072,6 +1072,7 @@ Date: December 2024
     background: inherit;
     padding: 4rem 1rem;
     text-align: center;
+    margin-top: 4rem; /* Added space above insurance section */
   }
 
   .insurance h2 {


### PR DESCRIPTION
## Summary
- add margin above the insurance carousel to separate it from the contact section

## Testing
- `node tests/maybeOfferAssessment.test.js && node tests/singleWordInputs.test.js && node tests/medicationQueries.test.js && node tests/textUpdates.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6860d848a46c832aa7e4cc6edcbfa9f6