### PR TITLE
Update text and styling for insurance section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1072,13 +1072,15 @@ Date: December 2024
     background: inherit;
     padding: 4rem 1rem;
     text-align: center;
-    margin-top: 4rem; /* Added space above insurance section */
+    margin-top: 6rem; /* Added extra space above insurance section */
   }
 
   .insurance h2 {
     font-size: clamp(1.6rem, 4vw + .5rem, 2.8rem);
     margin-bottom: 2.5rem;
     color: #fff;
+    font-family: 'Poppins', sans-serif;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
   }
 
   .logo-window {
@@ -1158,7 +1160,7 @@ Date: December 2024
   <section id="ai-chat">
     <div class="container">
       <h2 class="section-title">Ask Away We're Listening</h2>
-      <p class="chat-intro">Get instant answers on medications, mental health conditions, and quick wellness check-ins confidentially and judgment-free.</p>
+      <p class="chat-intro">Get detailed answers on medications, mental health conditions, and quick wellness check-ins confidentially and judgment free.</p>
 
       <div class="chat-interface">
         <div class="chat-messages" id="chatMessages">

--- a/tests/textUpdates.test.js
+++ b/tests/textUpdates.test.js
@@ -14,9 +14,9 @@ assert.ok(indexHtml.includes('Ask Away We\'re Listening'), 'Main heading should 
 assert.ok(!indexHtml.includes('Ask Away—We\'re Listening'), 'Should not contain the old heading with em dash');
 
 // Test 2: Check that the description text was updated correctly
-assert.ok(indexHtml.includes('Get instant answers on medications, mental health conditions, and quick wellness check-ins confidentially and judgment-free'), 'Description should mention medications and mental health conditions');
-assert.ok(!indexHtml.includes('judgment free'), 'Should contain hyphenated judgment-free');
-assert.ok(!indexHtml.includes('Get instant answers on mental health conditions, and quick wellness check-ins confidentially and judgment free'), 'Should not contain the old description without medications');
+assert.ok(indexHtml.includes('Get detailed answers on medications, mental health conditions, and quick wellness check-ins confidentially and judgment free'), 'Description should mention medications and mental health conditions');
+assert.ok(!indexHtml.includes('judgment-free'), 'Should not contain hyphenated judgment-free');
+assert.ok(!indexHtml.includes('Get instant answers on medications, mental health conditions, and quick wellness check-ins confidentially and judgment-free'), 'Should not contain the old description');
 
 // Test 3: Check that medical disclaimer was updated
 assert.ok(indexHtml.includes('I can provide general information about mental health and medications'), 'Medical disclaimer should mention mental health and medications');


### PR DESCRIPTION
## Summary
- refine chat intro text
- adjust insurance section styling with extra margin and font/shadow for heading
- update tests to match new copy

## Testing
- `node tests/textUpdates.test.js`
- `for file in tests/*.test.js; do node "$file"; done`

------
https://chatgpt.com/codex/tasks/task_e_6860fa569cd4832a874bd86a388feb7e