### PR TITLE
Remove insurance carousel

### DIFF
--- a/docs/assets/insurance/aetna.svg
+++ b/docs/assets/insurance/aetna.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 40">
-  <path d="M15 20c0-5 4-9 9-9s9 4 9 9c0 4-2 7-6 8v7h-6v-7c-4-1-6-4-6-8z" fill="#742384"/>
-  <text x="40" y="30" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#742384" font-weight="bold">aetna</text>
-</svg>

--- a/docs/assets/insurance/anthem.svg
+++ b/docs/assets/insurance/anthem.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 40">
-  <text x="0" y="30" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#005DAA" font-weight="bold">Anthem</text>
-  <rect x="120" y="5" width="8" height="30" fill="#005DAA"/>
-  <rect x="114" y="15" width="20" height="8" fill="#005DAA"/>
-</svg>

--- a/docs/assets/insurance/bluecross.svg
+++ b/docs/assets/insurance/bluecross.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 40">
-  <rect x="20" y="5" width="20" height="30" fill="#0072CE"/>
-  <rect x="10" y="15" width="40" height="10" fill="#0072CE"/>
-  <path d="M90 5l10 10 10-10h10v30h-10V15l-10 10-10-10v20H80V5h10z" fill="#0072CE"/>
-</svg>

--- a/docs/assets/insurance/cigna.svg
+++ b/docs/assets/insurance/cigna.svg
@@ -1,6 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
-  <circle cx="60" cy="20" r="10" fill="#6DBE45"/>
-  <path d="M60 30v20" stroke="#6DBE45" stroke-width="4"/>
-  <path d="M40 35c5-5 15-5 20 0s15 5 20 0" fill="none" stroke="#6DBE45" stroke-width="4"/>
-  <path d="M40 45c5-5 15-5 20 0s15 5 20 0" fill="none" stroke="#6DBE45" stroke-width="4"/>
-</svg>

--- a/docs/assets/insurance/humana.svg
+++ b/docs/assets/insurance/humana.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 40">
-  <text x="0" y="30" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#65B32E" font-weight="bold">Humana</text>
-</svg>

--- a/docs/assets/insurance/kaiser.svg
+++ b/docs/assets/insurance/kaiser.svg
@@ -1,6 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40">
-  <path d="M20 30L30 10l10 20 10-20 10 20 10-20 10 20" fill="#005DAA"/>
-  <circle cx="35" cy="5" r="5" fill="#005DAA"/>
-  <circle cx="55" cy="5" r="5" fill="#005DAA"/>
-  <circle cx="75" cy="5" r="5" fill="#005DAA"/>
-</svg>

--- a/docs/assets/insurance/medicaid.svg
+++ b/docs/assets/insurance/medicaid.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40">
-  <path d="M10 30h140" stroke="#005DAA" stroke-width="8"/>
-  <path d="M30 10l20 20 20-20" fill="none" stroke="#005DAA" stroke-width="8"/>
-</svg>

--- a/docs/assets/insurance/medicare.svg
+++ b/docs/assets/insurance/medicare.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40">
-  <path d="M20 30L40 10l20 20 20-20 20 20" fill="none" stroke="#005DAA" stroke-width="8"/>
-</svg>

--- a/docs/assets/insurance/optum.svg
+++ b/docs/assets/insurance/optum.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 40">
-  <polygon points="10,30 60,5 110,30 60,35" fill="#FF7E0A"/>
-</svg>

--- a/docs/assets/insurance/tricare.svg
+++ b/docs/assets/insurance/tricare.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40">
-  <polygon points="10,30 30,0 50,30" fill="#005DAA"/>
-  <polygon points="55,30 75,0 95,30" fill="#005DAA"/>
-  <polygon points="100,30 120,0 140,30" fill="#005DAA"/>
-  <line x1="10" y1="35" x2="140" y2="35" stroke="#C8102E" stroke-width="4"/>
-  <line x1="20" y1="38" x2="150" y2="38" stroke="#C8102E" stroke-width="4"/>
-</svg>

--- a/docs/assets/insurance/triwest.svg
+++ b/docs/assets/insurance/triwest.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40">
-  <polygon points="10,20 30,0 30,40" fill="#1A1F71"/>
-  <polygon points="150,20 130,0 130,40" fill="#1A1F71"/>
-  <polygon points="40,5 80,35 120,5 80,25" fill="#1A1F71"/>
-</svg>

--- a/docs/assets/insurance/united.svg
+++ b/docs/assets/insurance/united.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 60">
-  <path d="M20 0v35a30 30 0 0 0 60 0V0h-8v35a22 22 0 0 1-44 0V0h-8z" fill="#005DAA"/>
-</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1071,48 +1071,6 @@ Date: December 2024
   }
 }
 
-  /* ---------- INSURANCE CAROUSEL ---------- */
-  .insurance {
-    background: inherit;
-    padding: 4rem 1rem;
-    text-align: center;
-    margin-top: 6rem; /* Added extra space above insurance section */
-  }
-
-  .insurance h2 {
-    font-size: clamp(1.6rem, 4vw + .5rem, 2.8rem);
-    margin-bottom: 2.5rem;
-    color: #fff;
-    font-family: 'Poppins', sans-serif;
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
-  }
-
-  .logo-window {
-    overflow: hidden;
-    width: 100%;
-  }
-
-  .logo-track {
-    display: flex;
-    animation: scroll var(--scroll-duration) linear infinite;
-  }
-
-  .logo-track:hover {
-    animation-play-state: paused;
-  }
-
-  .logo-track img {
-    flex: 0 0 var(--slot-width);
-    max-height: var(--slot-height);
-    width: auto;
-    object-fit: contain;
-    margin: 0 1rem;
-  }
-
-  @keyframes scroll {
-    0%   { transform: translateX(0); }
-    100% { transform: translateX(calc(-1 * (var(--slot-width) + 2rem) * 12)); }
-  }
   </style>
 </head>
 
@@ -1309,40 +1267,6 @@ Date: December 2024
     </div>
   </section>
 
-  <!-- ─── INSURANCE CAROUSEL ─── -->
-  <section id="insurance" class="insurance">
-
-    <div class="logo-window">
-      <div class="logo-track">
-        <img src="assets/insurance/aetna.svg"      alt="Aetna">
-        <img src="assets/insurance/bluecross.svg"  alt="Blue Cross Blue Shield">
-        <img src="assets/insurance/cigna.svg"      alt="Cigna">
-        <img src="assets/insurance/united.svg"     alt="United Healthcare">
-        <img src="assets/insurance/humana.svg"     alt="Humana">
-        <img src="assets/insurance/medicare.svg"   alt="Medicare">
-        <img src="assets/insurance/medicaid.svg"   alt="Medicaid">
-        <img src="assets/insurance/optum.svg"      alt="Optum">
-        <img src="assets/insurance/kaiser.svg"     alt="Kaiser Permanente">
-        <img src="assets/insurance/anthem.svg"     alt="Anthem">
-        <img src="assets/insurance/tricare.svg"    alt="TRICARE">
-        <img src="assets/insurance/triwest.svg"    alt="TriWest">
-
-        <img src="assets/insurance/aetna.svg"      alt="">
-        <img src="assets/insurance/bluecross.svg"  alt="">
-        <img src="assets/insurance/cigna.svg"      alt="">
-        <img src="assets/insurance/united.svg"     alt="">
-        <img src="assets/insurance/humana.svg"     alt="">
-        <img src="assets/insurance/medicare.svg"   alt="">
-        <img src="assets/insurance/medicaid.svg"   alt="">
-        <img src="assets/insurance/optum.svg"      alt="">
-        <img src="assets/insurance/kaiser.svg"     alt="">
-        <img src="assets/insurance/anthem.svg"     alt="">
-        <img src="assets/insurance/tricare.svg"    alt="">
-        <img src="assets/insurance/triwest.svg"    alt="">
-      </div>
-    </div>
-  </section>
-  <!-- ──────────────────────────────────────────────────────────────────── -->
 
   <footer>
     <div class="container footer-flex">


### PR DESCRIPTION
## Summary
- remove insurance carousel section from homepage
- delete unused insurance logos

## Testing
- `node tests/maybeOfferAssessment.test.js`
- `node tests/medicationQueries.test.js`
- `node tests/singleWordInputs.test.js`
- `node tests/textUpdates.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6861c336b9a4832aae8e42ab4dc4c7f5