### PR TITLE
Switch headlines to serif for better hierarchy

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@ Date: December 2024
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fernly Health - Mental Wellness Reimagined</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
   <!-- SMART AI SYSTEM - BROWSER-COMPATIBLE INTELLIGENT RESPONSES -->
   <!-- Reliable pattern-based AI with comprehensive mental health knowledge -->
   <!-- No external dependencies - works perfectly with static hosting -->
@@ -73,6 +73,11 @@ Date: December 2024
       height: 100%;
       font-family: 'Poppins', sans-serif;
       color: #333;
+    }
+
+    h1,
+    h2 {
+      font-family: 'Domine', serif;
     }
 
     body {

--- a/docs/login.html
+++ b/docs/login.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - Fernly Health</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --g1: #8fbf8f;
@@ -38,6 +38,11 @@
       background-size: 400% 400%;
       animation: moodShift 12s ease-in-out infinite;
       position: relative;
+    }
+
+    h1,
+    h2 {
+      font-family: 'Domine', serif;
     }
 
     body::before {

--- a/docs/services.html
+++ b/docs/services.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Our Services - Fernly Health</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --g1: #8fbf8f;
@@ -39,6 +39,11 @@
       background-size: 400% 400%;
       animation: moodShift 12s ease-in-out infinite;
       position: relative;
+    }
+
+    h1,
+    h2 {
+      font-family: 'Domine', serif;
     }
 
     body::before {

--- a/docs/team.html
+++ b/docs/team.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Meet Our Team - Fernly Health</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --g1: #8fbf8f;
@@ -39,6 +39,11 @@
       background-size: 400% 400%;
       animation: moodShift 12s ease-in-out infinite;
       position: relative;
+    }
+
+    h1,
+    h2 {
+      font-family: 'Domine', serif;
     }
 
     body::before {


### PR DESCRIPTION
## Summary
- include the "Domine" typeface alongside Poppins
- use the serif on all `h1` and `h2` elements

## Testing
- `node tests/maybeOfferAssessment.test.js`
- `node tests/singleWordInputs.test.js`
- `node tests/medicationQueries.test.js`
- `node tests/textUpdates.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68621710b4b0832aa44ea954379ddde0