### PR TITLE
Revert typography changes and soften text shadows

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@ Date: December 2024
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fernly Health - Mental Wellness Reimagined</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=DM+Serif+Display&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
   <!-- SMART AI SYSTEM - BROWSER-COMPATIBLE INTELLIGENT RESPONSES -->
   <!-- Reliable pattern-based AI with comprehensive mental health knowledge -->
   <!-- No external dependencies - works perfectly with static hosting -->
@@ -71,13 +71,13 @@ Date: December 2024
     html,
     body {
       height: 100%;
-      font-family: 'Inter', sans-serif;
+      font-family: 'Poppins', sans-serif;
       color: #333;
     }
 
     h1,
     h2 {
-      font-family: 'DM Serif Display', serif;
+      font-family: 'Domine', serif;
     }
 
     body {
@@ -379,14 +379,15 @@ Date: December 2024
     .hero h1 {
       font-size: 3.5rem;
       margin-bottom: 1rem;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
       font-weight: 700;
-      color: #eee;
     }
 
     .hero .tagline {
       font-size: 1.3rem;
       max-width: 700px;
       margin: 0 auto 2rem;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
       font-weight: 300;
       opacity: 0;
       transform: translateY(20px);
@@ -831,6 +832,7 @@ Date: December 2024
       color: #fff;
       font-size: 2.5rem;
       margin-bottom: 3rem;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
     }
 
     .blog-grid {
@@ -1114,7 +1116,9 @@ Date: December 2024
       </h1>
       <p class="tagline">Because just 'okay' isn't good enough</p>
       <div class="hero-buttons">
-        <a href="#contact" class="btn-primary">Book Free Consultation</a>
+        <a href="#ai-chat" class="btn-ai">Chat with Fernly</a>
+        <a href="services.html" class="btn-primary">Our Services</a>
+        <a href="#contact" class="btn-secondary">Free Consultation</a>
       </div>
     </div>
   </section>

--- a/docs/login.html
+++ b/docs/login.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - Fernly Health</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=DM+Serif+Display&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --g1: #8fbf8f;
@@ -24,7 +24,7 @@
     html,
     body {
       height: 100%;
-      font-family: 'Inter', sans-serif;
+      font-family: 'Poppins', sans-serif;
       color: #333;
       background: linear-gradient(
           45deg,
@@ -42,7 +42,7 @@
 
     h1,
     h2 {
-      font-family: 'DM Serif Display', serif;
+      font-family: 'Domine', serif;
     }
 
     body::before {

--- a/docs/services.html
+++ b/docs/services.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Our Services - Fernly Health</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=DM+Serif+Display&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --g1: #8fbf8f;
@@ -25,7 +25,7 @@
     html,
     body {
       height: 100%;
-      font-family: 'Inter', sans-serif;
+      font-family: 'Poppins', sans-serif;
       color: #333;
       background: linear-gradient(
           45deg,
@@ -43,7 +43,7 @@
 
     h1,
     h2 {
-      font-family: 'DM Serif Display', serif;
+      font-family: 'Domine', serif;
     }
 
     body::before {
@@ -179,6 +179,7 @@
     .page-header h1 {
       font-size: 3rem;
       margin-bottom: 1rem;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
       font-weight: 700;
     }
 
@@ -186,6 +187,7 @@
       font-size: 1.2rem;
       max-width: 600px;
       margin: 0 auto;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
       font-weight: 300;
     }
 
@@ -199,6 +201,7 @@
       color: #fff;
       font-size: 2.5rem;
       margin-bottom: 3rem;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
     }
 
     .services-grid {

--- a/docs/team.html
+++ b/docs/team.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Meet Our Team - Fernly Health</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=DM+Serif+Display&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --g1: #8fbf8f;
@@ -25,7 +25,7 @@
     html,
     body {
       height: 100%;
-      font-family: 'Inter', sans-serif;
+      font-family: 'Poppins', sans-serif;
       color: #333;
       background: linear-gradient(
           45deg,
@@ -43,7 +43,7 @@
 
     h1,
     h2 {
-      font-family: 'DM Serif Display', serif;
+      font-family: 'Domine', serif;
     }
 
     body::before {
@@ -179,6 +179,7 @@
     .page-header h1 {
       font-size: 3rem;
       margin-bottom: 1rem;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
       font-weight: 700;
     }
 
@@ -186,6 +187,7 @@
       font-size: 1.2rem;
       max-width: 600px;
       margin: 0 auto;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
       font-weight: 300;
     }
 
@@ -199,6 +201,7 @@
       color: #fff;
       font-size: 2.5rem;
       margin-bottom: 3rem;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
     }
 
     .team-grid {


### PR DESCRIPTION
## Summary
- revert previous typography update
- restore original layout with Inter font replaced by Poppins
- lighten text-shadow on hero headings and section headers

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6862222abce0832ab3803f2e2b13fa94