### PR TITLE
Improve typography and layout spacing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@ Date: December 2024
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fernly Health - Mental Wellness Reimagined</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
   <!-- SMART AI SYSTEM - BROWSER-COMPATIBLE INTELLIGENT RESPONSES -->
   <!-- Reliable pattern-based AI with comprehensive mental health knowledge -->
   <!-- No external dependencies - works perfectly with static hosting -->
@@ -77,7 +77,7 @@ Date: December 2024
 
     h1,
     h2 {
-      font-family: 'Domine', serif;
+      font-family: 'Playfair Display', Georgia, serif;
     }
 
     body {
@@ -119,7 +119,7 @@ Date: December 2024
 
     section {
       margin: 0;
-      padding: 4rem 0;
+      padding: 6rem 0;
     }
 
     @keyframes moodShift {
@@ -271,7 +271,7 @@ Date: December 2024
     .nav-links {
       list-style: none;
       display: flex;
-      gap: 2rem;
+      gap: 2.5rem;
       align-items: center;
     }
 
@@ -309,6 +309,7 @@ Date: December 2024
       font-weight: 600;
       transition: all 0.3s ease;
       border: 2px solid #619251;
+      margin: 0.5rem;
     }
 
     .btn-primary:hover {
@@ -325,6 +326,7 @@ Date: December 2024
       font-weight: 600;
       border: 2px solid #fff;
       transition: all 0.3s ease;
+      margin: 0.5rem;
     }
 
     .btn-secondary:hover {

--- a/docs/login.html
+++ b/docs/login.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - Fernly Health</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --g1: #8fbf8f;
@@ -42,7 +42,7 @@
 
     h1,
     h2 {
-      font-family: 'Domine', serif;
+      font-family: 'Playfair Display', Georgia, serif;
     }
 
     body::before {
@@ -119,7 +119,7 @@
     .nav-links {
       list-style: none;
       display: flex;
-      gap: 2rem;
+      gap: 2.5rem;
       align-items: center;
     }
 
@@ -160,6 +160,7 @@
       border: none;
       cursor: pointer;
       text-decoration: none;
+      margin: 0.5rem;
     }
 
     .btn-primary:hover {
@@ -169,7 +170,7 @@
 
     main {
       margin-top: 100px;
-      padding: 2rem 0;
+      padding: 3rem 0;
       min-height: calc(100vh - 100px);
       display: flex;
       align-items: center;

--- a/docs/services.html
+++ b/docs/services.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Our Services - Fernly Health</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --g1: #8fbf8f;
@@ -43,7 +43,7 @@
 
     h1,
     h2 {
-      font-family: 'Domine', serif;
+      font-family: 'Playfair Display', Georgia, serif;
     }
 
     body::before {
@@ -124,7 +124,7 @@
     .nav-links {
       list-style: none;
       display: flex;
-      gap: 2rem;
+      gap: 2.5rem;
       align-items: center;
     }
 
@@ -161,6 +161,7 @@
       font-weight: 600;
       transition: all 0.3s ease;
       border: 2px solid #619251;
+      margin: 0.5rem;
     }
 
     .btn-primary:hover {
@@ -192,7 +193,7 @@
     }
 
     #services {
-      padding: 4rem 0;
+      padding: 6rem 0;
       background: transparent;
     }
 

--- a/docs/team.html
+++ b/docs/team.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Meet Our Team - Fernly Health</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --g1: #8fbf8f;
@@ -43,7 +43,7 @@
 
     h1,
     h2 {
-      font-family: 'Domine', serif;
+      font-family: 'Playfair Display', Georgia, serif;
     }
 
     body::before {
@@ -124,7 +124,7 @@
     .nav-links {
       list-style: none;
       display: flex;
-      gap: 2rem;
+      gap: 2.5rem;
       align-items: center;
     }
 
@@ -161,6 +161,7 @@
       font-weight: 600;
       transition: all 0.3s ease;
       border: 2px solid #619251;
+      margin: 0.5rem;
     }
 
     .btn-primary:hover {
@@ -192,7 +193,7 @@
     }
 
     #team {
-      padding: 4rem 0;
+      padding: 6rem 0;
       background: transparent;
     }
 
@@ -257,7 +258,7 @@
 
     #founders-note {
       color: white;
-      padding: 4rem 0;
+      padding: 6rem 0;
       background: transparent;
     }
 


### PR DESCRIPTION
## Summary
- use Playfair Display for headings
- widen gaps between navigation items
- add breathing room around primary buttons
- extend section padding for more whitespace

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68622733c834832a9c2a63767f1e7b29