### PR TITLE
Improve heading typography

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@ Date: December 2024
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fernly Health - Mental Wellness Reimagined</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
   <!-- SMART AI SYSTEM - BROWSER-COMPATIBLE INTELLIGENT RESPONSES -->
   <!-- Reliable pattern-based AI with comprehensive mental health knowledge -->
   <!-- No external dependencies - works perfectly with static hosting -->
@@ -77,7 +77,7 @@ Date: December 2024
 
     h1,
     h2 {
-      font-family: 'Domine', serif;
+      font-family: 'Playfair Display', serif;
     }
 
     body {

--- a/docs/login.html
+++ b/docs/login.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - Fernly Health</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --g1: #8fbf8f;
@@ -42,7 +42,7 @@
 
     h1,
     h2 {
-      font-family: 'Domine', serif;
+      font-family: 'Playfair Display', serif;
     }
 
     body::before {

--- a/docs/services.html
+++ b/docs/services.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Our Services - Fernly Health</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --g1: #8fbf8f;
@@ -43,7 +43,7 @@
 
     h1,
     h2 {
-      font-family: 'Domine', serif;
+      font-family: 'Playfair Display', serif;
     }
 
     body::before {

--- a/docs/team.html
+++ b/docs/team.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Meet Our Team - Fernly Health</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Domine:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --g1: #8fbf8f;
@@ -43,7 +43,7 @@
 
     h1,
     h2 {
-      font-family: 'Domine', serif;
+      font-family: 'Playfair Display', serif;
     }
 
     body::before {


### PR DESCRIPTION
## Summary
- pair existing sans-serif styles with a more elegant serif
- replace Domine with Playfair Display for headings across site

## Testing
- `node tests/maybeOfferAssessment.test.js`
- `node tests/medicationQueries.test.js`
- `node tests/singleWordInputs.test.js`
- `node tests/textUpdates.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68623363c860832abf64749026713b5f