### PR TITLE
Add scroll reveal animations

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -122,6 +122,12 @@ Date: December 2024
       padding: 4rem 0;
     }
 
+    .scroll-reveal {
+      opacity: 0;
+      transform: translateY(30px);
+      transition: opacity 0.6s ease, transform 0.6s ease;
+    }
+
     @keyframes moodShift {
       0% {
         background-position: 0% 50%;
@@ -1555,12 +1561,16 @@ const observer = new IntersectionObserver((entries) => {
   });
 }, observerOptions);
 
-// Observe all cards and team members
+// Observe all cards
 document.querySelectorAll('.blog-card').forEach(el => {
-  el.style.opacity = '0';
-  el.style.transform = 'translateY(30px)';
-  el.style.transition = 'opacity 0.6s ease, transform 0.6s ease';
+  el.classList.add('scroll-reveal');
   observer.observe(el);
+});
+
+// Reveal sections after hero
+document.querySelectorAll('section:not(.hero)').forEach(sec => {
+  sec.classList.add('scroll-reveal');
+  observer.observe(sec);
 });
 
 </script>

--- a/docs/services.html
+++ b/docs/services.html
@@ -62,6 +62,12 @@
       background: transparent;
     }
 
+    .scroll-reveal {
+      opacity: 0;
+      transform: translateY(30px);
+      transition: opacity 0.6s ease, transform 0.6s ease;
+    }
+
     @keyframes moodShift {
       0% {
         background-position: 0% 50%;
@@ -414,10 +420,14 @@
 
     // Observe all cards
     document.querySelectorAll('.card').forEach(el => {
-      el.style.opacity = '0';
-      el.style.transform = 'translateY(30px)';
-      el.style.transition = 'opacity 0.6s ease, transform 0.6s ease';
+      el.classList.add('scroll-reveal');
       observer.observe(el);
+    });
+
+    // Reveal sections after header
+    document.querySelectorAll('section:not(.page-header)').forEach(sec => {
+      sec.classList.add('scroll-reveal');
+      observer.observe(sec);
     });
   </script>
 </body>

--- a/docs/team.html
+++ b/docs/team.html
@@ -62,6 +62,12 @@
       background: transparent;
     }
 
+    .scroll-reveal {
+      opacity: 0;
+      transform: translateY(30px);
+      transition: opacity 0.6s ease, transform 0.6s ease;
+    }
+
     @keyframes moodShift {
       0% {
         background-position: 0% 50%;
@@ -459,10 +465,14 @@
 
     // Observe all team members
     document.querySelectorAll('.team-member').forEach(el => {
-      el.style.opacity = '0';
-      el.style.transform = 'translateY(30px)';
-      el.style.transition = 'opacity 0.6s ease, transform 0.6s ease';
+      el.classList.add('scroll-reveal');
       observer.observe(el);
+    });
+
+    // Reveal sections after header
+    document.querySelectorAll('section:not(.page-header)').forEach(sec => {
+      sec.classList.add('scroll-reveal');
+      observer.observe(sec);
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- introduce `.scroll-reveal` class for fade-in effect
- activate scroll-based reveals for sections and cards on all pages

## Testing
- `node tests/maybeOfferAssessment.test.js`
- `node tests/medicationQueries.test.js`
- `node tests/singleWordInputs.test.js`
- `node tests/textUpdates.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6864a7421cd8832ab545580c11af62bf