### PR TITLE
Smooth scroll reveal animations

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -124,8 +124,8 @@ Date: December 2024
 
     .scroll-reveal {
       opacity: 0;
-      transform: translateY(30px);
-      transition: opacity 0.6s ease, transform 0.6s ease;
+      transform: translateY(20px);
+      transition: opacity 1s ease-out, transform 1s ease-out;
     }
 
     @keyframes moodShift {
@@ -1557,6 +1557,7 @@ const observer = new IntersectionObserver((entries) => {
     if (entry.isIntersecting) {
       entry.target.style.opacity = '1';
       entry.target.style.transform = 'translateY(0)';
+      observer.unobserve(entry.target);
     }
   });
 }, observerOptions);

--- a/docs/services.html
+++ b/docs/services.html
@@ -64,8 +64,8 @@
 
     .scroll-reveal {
       opacity: 0;
-      transform: translateY(30px);
-      transition: opacity 0.6s ease, transform 0.6s ease;
+      transform: translateY(20px);
+      transition: opacity 1s ease-out, transform 1s ease-out;
     }
 
     @keyframes moodShift {
@@ -414,6 +414,7 @@
         if (entry.isIntersecting) {
           entry.target.style.opacity = '1';
           entry.target.style.transform = 'translateY(0)';
+          observer.unobserve(entry.target);
         }
       });
     }, observerOptions);

--- a/docs/team.html
+++ b/docs/team.html
@@ -64,8 +64,8 @@
 
     .scroll-reveal {
       opacity: 0;
-      transform: translateY(30px);
-      transition: opacity 0.6s ease, transform 0.6s ease;
+      transform: translateY(20px);
+      transition: opacity 1s ease-out, transform 1s ease-out;
     }
 
     @keyframes moodShift {
@@ -459,6 +459,7 @@
         if (entry.isIntersecting) {
           entry.target.style.opacity = '1';
           entry.target.style.transform = 'translateY(0)';
+          observer.unobserve(entry.target);
         }
       });
     }, observerOptions);


### PR DESCRIPTION
## Summary
- slow down the `.scroll-reveal` transition to make fades smoother
- make animations run once by unobserving after reveal

## Testing
- `node tests/maybeOfferAssessment.test.js && node tests/medicationQueries.test.js && node tests/singleWordInputs.test.js && node tests/textUpdates.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6864a908ed14832a9d65ecc60df4c158