### PR TITLE
Ensure scroll reveals show even when IntersectionObserver unavailable

### DIFF
--- a/docs/scrollReveal.js
+++ b/docs/scrollReveal.js
@@ -1,5 +1,15 @@
 (function() {
   function init() {
+    if (!('IntersectionObserver' in window)) {
+      Array.prototype.forEach.call(
+        document.querySelectorAll('.scroll-reveal'),
+        function(el) {
+          el.style.opacity = '1';
+          el.style.transform = 'none';
+        }
+      );
+      return;
+    }
     const observerOptions = {
       threshold: 0.1,
       rootMargin: '0px 0px -50px 0px'


### PR DESCRIPTION
## Summary
- enhance `scrollReveal.js` to fallback gracefully when `IntersectionObserver` isn't supported
- avoid `NodeList.forEach` for better IE compatibility

## Testing
- `for f in tests/*.test.js; do node $f || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_6864aec8f9d0832aa64885d38dc97752