### PR TITLE
Remove hyphens in homepage text

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1491,7 +1491,7 @@ Date: December 2024
              aria-labelledby="step-1-tab" 
              id="step-1-content">
           <h3 class="stepper-content__title">Schedule Your Intake Appointment</h3>
-          <p class="stepper-content__text">Complete our secure online intake form—share your background, goals, and insurance details—then pick an in-person or virtual appointment time that fits your schedule. We’ll confirm your slot right away so you can start without any phone tag or waiting rooms.</p>
+          <p class="stepper-content__text">Complete our secure online intake form—share your background, goals, and insurance details—then pick an inperson or virtual appointment time that fits your schedule. We’ll confirm your slot right away so you can start without any phone tag or waiting rooms.</p>
           <a href="#contact" class="stepper-content__cta btn-primary">Schedule Now</a>
         </div>
         
@@ -1500,7 +1500,7 @@ Date: December 2024
              aria-labelledby="step-2-tab" 
              id="step-2-content">
           <h3 class="stepper-content__title">Meet Your Dedicated Healthcare Team</h3>
-          <p class="stepper-content__text">Join a 20-minute welcome session—either in our bright, Tucson clinic or via HIPAA-secure video—with your care coordinator and board-certified PMHNP (or therapist). You’ll review your intake, discuss your history, and define clear, personalized treatment goals.</p>
+          <p class="stepper-content__text">Join a 20minute welcome session—either in our bright, Tucson clinic or via HIPAAsecure video—with your care coordinator and boardcertified PMHNP (or therapist). You’ll review your intake, discuss your history, and define clear, personalized treatment goals.</p>
           <a href="team.html" class="stepper-content__cta btn-primary">Meet Our Team</a>
         </div>
         
@@ -1509,7 +1509,7 @@ Date: December 2024
              aria-labelledby="step-3-tab" 
              id="step-3-content">
           <h3 class="stepper-content__title">Choose Your Treatment Services</h3>
-          <p class="stepper-content__text">Browse our full continuum of care: day-long Partial Hospitalization (PHP), three-times-weekly Intensive Outpatient (IOP) groups, individual therapy, medication-assisted treatment (MAT), and skill-building workshops. Mix and match in-person or telehealth options to build the plan that’s right for you.</p>
+          <p class="stepper-content__text">Browse our full continuum of care: daylong Partial Hospitalization (PHP), threetimesweekly Intensive Outpatient (IOP) groups, individual therapy, medicationassisted treatment (MAT), and skillbuilding workshops. Mix and match inperson or telehealth options to build the plan that’s right for you.</p>
           <a href="services.html" class="stepper-content__cta btn-primary">View Services</a>
         </div>
         
@@ -1518,7 +1518,7 @@ Date: December 2024
              aria-labelledby="step-4-tab" 
              id="step-4-content">
           <h3 class="stepper-content__title">Begin Your Treatment Journey</h3>
-          <p class="stepper-content__text">Kick off your personalized program with scheduled PHP/IOP attendance, one-on-one therapy, and regular MAT check-ins. You’ll also have 24/7 access to our AI wellness assistant and optional peer support groups, so you’re supported every step of the way.</p>
+          <p class="stepper-content__text">Kick off your personalized program with scheduled PHP/IOP attendance, oneonone therapy, and regular MAT checkins. You’ll also have 24/7 access to our AI wellness assistant and optional peer support groups, so you’re supported every step of the way.</p>
         </div>
       </div>
     </div>
@@ -1529,7 +1529,7 @@ Date: December 2024
   <section id="ai-chat" data-aos="fade-up">
     <div class="container">
       <h2 class="section-title" data-aos="fade-up" data-aos-delay="100">Ask Away We're Listening</h2>
-      <p class="chat-intro" data-aos="fade-up" data-aos-delay="200">Have a quick question about your prescription or wellness plan but can’t make it into the clinic? Fernly AI delivers private, judgment free guidance 24/7 on medications, mental health conditions, and mini wellness check-ins. Just type your question and get clear, expert backed answers in seconds.</p>
+      <p class="chat-intro" data-aos="fade-up" data-aos-delay="200">Have a quick question about your prescription or wellness plan but can’t make it into the clinic? Fernly AI delivers private, judgment free guidance 24/7 on medications, mental health conditions, and mini wellness checkins. Just type your question and get clear, expert backed answers in seconds.</p>
 
       <div class="chat-interface">
         <div class="chat-messages" id="chatMessages">
@@ -1604,7 +1604,7 @@ Date: December 2024
             <div class="blog-source">Psychology Today</div>
             <div class="blog-date"></div>
             <h3 class="blog-title">What to Do When Your Anxiety Won't Go Away</h3>
-            <p class="blog-excerpt">A practical guide to calming persistent anxiety using simple, everyday strategies rooted in mindfulness and self-care.</p>
+            <p class="blog-excerpt">A practical guide to calming persistent anxiety using simple, everyday strategies rooted in mindfulness and selfcare.</p>
             <a href="https://www.psychologytoday.com/us/blog/anxiety-zen/201505/what-do-when-your-anxiety-won-t-go-away" target="_blank" class="read-more">Read More →</a>
           </div>
         </div>
@@ -1616,7 +1616,7 @@ Date: December 2024
             <div class="blog-source">American Psychological Association</div>
             <div class="blog-date"></div>
             <h3 class="blog-title">The Science of Resilience: Building Mental Strength</h3>
-            <p class="blog-excerpt">Evidence-based strategies for developing psychological resilience and coping mechanisms in challenging times.</p>
+            <p class="blog-excerpt">Evidencebased strategies for developing psychological resilience and coping mechanisms in challenging times.</p>
             <a href="https://www.apa.org/topics/resilience" target="_blank" class="read-more">Read More →</a>
           </div>
         </div>
@@ -1628,7 +1628,7 @@ Date: December 2024
             <div class="blog-source">PsychCentral</div>
             <div class="blog-date"></div>
             <h3 class="blog-title">Mindfulness and Recovery: A Holistic Approach</h3>
-            <p class="blog-excerpt">How mindfulness practices can enhance traditional therapy and support long-term mental health recovery.</p>
+            <p class="blog-excerpt">How mindfulness practices can enhance traditional therapy and support longterm mental health recovery.</p>
             <a href="https://psychcentral.com/blog/mindfulness-in-mental-health-recovery" target="_blank" class="read-more">Read More →</a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove hyphen characters from homepage text
- preserve the page title and contact section

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6879d9262d50832aad9ca082c759875a